### PR TITLE
chore: remove dependency from Jest plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@arkweid/lefthook": "0.7.6",
     "@bhovhannes/shared-config": "0.0.1",
     "@nrwl/cli": "13.2.3",
-    "@nrwl/jest": "13.2.3",
     "@nrwl/tao": "13.2.3",
     "@nrwl/workspace": "13.2.3",
     "@types/node": "14.14.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,7 +1444,6 @@ __metadata:
     "@arkweid/lefthook": 0.7.6
     "@bhovhannes/shared-config": 0.0.1
     "@nrwl/cli": 13.2.3
-    "@nrwl/jest": 13.2.3
     "@nrwl/tao": 13.2.3
     "@nrwl/workspace": 13.2.3
     "@types/node": 14.14.33


### PR DESCRIPTION
Everything seems to be working without that plugin, I guess it comes by default.