### PR TITLE
feat: add bundle-size plugin boilerplate as an example

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -80,3 +80,11 @@ Plugin's `package.json` in this case has the following look:
 ```
 
 All official plugins are published under `@bundle-validator` scope. For example, `@bundle-validator/plugin-check-size`.
+
+## Creating a new plugin
+
+Run `nx` generator named `plugin` to produce a plugin boilerplate and start coding:
+
+```shell
+yarn nx workspace-generator plugin <name>
+```

--- a/packages/plugin-bundle-size/README.md
+++ b/packages/plugin-bundle-size/README.md
@@ -1,0 +1,26 @@
+# @bundle-validator/plugin-bundle-size
+
+## Usage
+
+1. Add plugin package as a devDependency:
+   ```shell
+   npm install @bundle-validator/plugin-bundle-size --save-dev
+   ```
+   or
+   ```shell
+   yarn add @bundle-validator/plugin-bundle-size --save-dev
+   ```
+2. Add this plugin to the `plugins` array of `bundle-validator` config:
+
+   ```json
+   {
+     "plugins": [
+       {
+         "name": "@bundle-validator/plugin-bundle-size",
+         "options": {}
+       }
+     ]
+   }
+   ```
+
+## Options

--- a/packages/plugin-bundle-size/package.json
+++ b/packages/plugin-bundle-size/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "plugin-bundle-size",
+  "version": "0.0.0",
+  "description": "A plugin for bundle-validator tool",
+  "main": "./src/index.js",
+  "scripts": {
+    "test": "echo \"No test\" || exit 0",
+    "format": "prettier --write '**/*.{ts,tsx,js,jsx,css,md,yml}'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bhovhannes/bundle-validator.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bhovhannes/bundle-validator/issues"
+  },
+  "homepage": "https://github.com/bhovhannes/bundle-validator/tree/main/packages/plugin-bundle-size#readme",
+  "devDependencies": {
+    "@jest/globals": "27.4.2",
+    "jest": "27.4.3"
+  }
+}

--- a/packages/plugin-bundle-size/src/index.js
+++ b/packages/plugin-bundle-size/src/index.js
@@ -1,0 +1,17 @@
+function run(executionContext, pluginOptions) {
+  // TODO  Add plugin code
+  executionContext.log(
+    'debug',
+    `Executing plugin '@bundle-validator/plugin-bundle-size' for file '${executionContext.filePath}'`
+  )
+  executionContext.log('debug', pluginOptions)
+
+  return {
+    message: '',
+    status: 'pass'
+  }
+}
+
+module.exports = {
+  run
+}

--- a/tools/generators/plugin/files/README.md
+++ b/tools/generators/plugin/files/README.md
@@ -1,0 +1,26 @@
+# @bundle-validator/<%= name %>
+
+## Usage
+
+1. Add plugin package as a devDependency:
+   ```shell
+   npm install @bundle-validator/<%= name %> --save-dev
+   ```
+   or
+   ```shell
+   yarn add @bundle-validator/<%= name %> --save-dev
+   ```
+2. Add this plugin to the `plugins` array of `bundle-validator` config:
+
+   ```json
+   {
+     "plugins": [
+       {
+         "name": "@bundle-validator/<%= name %>",
+         "options": {}
+       }
+     ]
+   }
+   ```
+
+## Options

--- a/tools/generators/plugin/files/package.json
+++ b/tools/generators/plugin/files/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@bundle-validator/<%= name %>",
+  "version": "0.0.0",
+  "description": "A plugin for bundle-validator tool",
+  "main": "./src/index.js",
+  "scripts": {
+    "test": "jest -c ./test/jest.config.js",
+    "format": "prettier --write '**/*.{ts,tsx,js,jsx,css,md,yml}'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bhovhannes/bundle-validator.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bhovhannes/bundle-validator/issues"
+  },
+  "homepage": "https://github.com/bhovhannes/bundle-validator/tree/main/packages/<%= name %>#readme",
+  "devDependencies": {}
+}

--- a/tools/generators/plugin/files/src/index.js
+++ b/tools/generators/plugin/files/src/index.js
@@ -1,0 +1,17 @@
+function run(executionContext, pluginOptions) {
+  // TODO  Add plugin code
+  executionContext.log(
+    'debug',
+    `Executing plugin '<%= name %>' for file '${executionContext.filePath}'`
+  )
+  executionContext.log('debug', pluginOptions)
+
+  return {
+    message: '',
+    status: 'pass'
+  }
+}
+
+module.exports = {
+  run
+}

--- a/tools/generators/plugin/index.ts
+++ b/tools/generators/plugin/index.ts
@@ -1,0 +1,25 @@
+import {
+  Tree,
+  formatFiles,
+  installPackagesTask,
+  generateFiles,
+  joinPathFragments,
+  readProjectConfiguration
+} from '@nrwl/devkit'
+// import { libraryGenerator } from '@nrwl/workspace';
+
+export default async function (tree: Tree, schema: any) {
+  // TODO  Write a simple generator without eslint, etc.
+  // await libraryGenerator(tree, { name: schema.name });
+  const libraryRoot = readProjectConfiguration(tree, schema.name).root
+  generateFiles(
+    tree, // the virtual file system
+    joinPathFragments(__dirname, './files'), // path to the file templates
+    libraryRoot, // destination path of the files
+    schema // config object to replace variable in file templates
+  )
+  await formatFiles(tree)
+  return () => {
+    installPackagesTask(tree)
+  }
+}

--- a/tools/generators/plugin/schema.json
+++ b/tools/generators/plugin/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "plugin",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    }
+  },
+  "required": ["name"]
+}

--- a/workspace.json
+++ b/workspace.json
@@ -1,6 +1,9 @@
 {
   "version": 2,
   "projects": {
+    "bundle-size": {
+      "root": "packages/bundle-size"
+    },
     "cli": {
       "root": "packages/cli"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4576,6 +4576,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plugin-bundle-size@workspace:packages/plugin-bundle-size":
+  version: 0.0.0-use.local
+  resolution: "plugin-bundle-size@workspace:packages/plugin-bundle-size"
+  dependencies:
+    "@jest/globals": 27.4.2
+    jest: 27.4.3
+  languageName: unknown
+  linkType: soft
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"


### PR DESCRIPTION
This adds boilerplate for bundle-size plugin.

I've tried to use [nx generator](https://nx.dev/l/r/generators/workspace-generators), but its default code generates a lot and even altered repository root significantly, so we don't need that. We need to write a custom generator from scratch. Leaving generator folder for now, maybe we can iterate on that.